### PR TITLE
[Minor] Formatting Revision on "hostname to resolve addresses" section

### DIFF
--- a/source/topics/tutorials/config_pitfalls.txt
+++ b/source/topics/tutorials/config_pitfalls.txt
@@ -578,7 +578,7 @@ Using a Hostname to Resolve Addresses
 
 BAD:
 
-.. ngx::
+.. ngx:: warn
 
     upstream {
         server http://someserver;


### PR DESCRIPTION
New "hostname to resolve addresses" section doesn't use the 'warn' formatting on the code block, like in other sections.